### PR TITLE
Fixing details panel visibility issue

### DIFF
--- a/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
+++ b/Microsoft.Toolkit.Uwp.UI.Controls/MasterDetailsView/MasterDetailsView.xaml
@@ -139,6 +139,7 @@
                                 <VisualState x:Name="HasSelection">
                                     <VisualState.Setters>
                                         <Setter Target="NoSelectionPresenter.Visibility" Value="Collapsed" />
+                                       <Setter Target="SelectionDetailsPanel.Visibility" Value="Visible" />
                                     </VisualState.Setters>
                                 </VisualState>
                                 <VisualState x:Name="NoSelectionNarrow">


### PR DESCRIPTION
When an selected item is set from code behind  or ViewModel , details panel is getting collapsed.
Fixing it by toggling the visibility for HasSelection state